### PR TITLE
Some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ export FLASK_APP=./autoapp.py
 Flask db init
 Flask db migrate
 Flask db upgrade
+mv macro.db ../macro.db
 ```
 
 To generate a load run from the root:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,8 @@ Flask-JWT-Extended==3.18.0
 unicode_slugify==0.1.3
 Flask-Migrate==2.4.0
 Flask-Cors==3.0.7
+
+
+
+
+webargs==5.4.0


### PR DESCRIPTION
- If you currently follow the instructions given in the README.md to initialise the DB for the macro benchmark, a file called `macro.db` will be created in the `macro/` directory. The next step tells you to run `python -m caller --load true` but because this is ran from the root, it can't find `macro.db`. Added a step to move this file to the root.

- The `webargs` package is used somewhere in one of the dependencies but breaks on a newer version of `webargs`. Locking this version resolves that.

P.S. Thanks for creating this @bogdanp05 ! This will be of great help for my thesis